### PR TITLE
Add workspace build command

### DIFF
--- a/poetry_workspace_plugin/console/commands/build.py
+++ b/poetry_workspace_plugin/console/commands/build.py
@@ -1,0 +1,123 @@
+from pathlib import Path
+
+from cleo.helpers import option
+from cleo.io.outputs.output import Verbosity
+from poetry.console.commands.command import Command
+from poetry.factory import Factory
+from poetry.core.masonry.builder import Builder
+from poetry.core.packages.dependency import Dependency
+from poetry.core.packages.directory_dependency import DirectoryDependency
+from poetry.utils.env import EnvManager
+
+from poetry_workspace_plugin.helpers import get_workspaces_table, get_parent, get_dependency_range, \
+    get_dependency_ranges
+
+
+class WorkspaceBuildCommand(Command):
+    name = "workspace build"
+    description = "Builds each workspace package, as a tarball and a wheel by default."
+
+    options = [
+        option("format", "f", "Limit the format to either sdist or wheel.", flag=False),
+        option(
+            "targets",
+            "t",
+            "Comma-separated list of target workspaces by name. Omit to run the command in all tracked workspaces.",
+            flag=False,
+            default=None,
+        )
+    ]
+
+    help = """The build command builds workspace packages.
+
+If invoked in a workspace, it builds the current workspace, resolving any directory dependency pointing to another
+workspace to a regular dependency using its version number.
+
+When invoked in the workspaces root, it will build all of its workspaces.
+"""
+
+    def handle(self) -> int:
+        parent = get_parent(self.poetry.file.read())
+        workspaces = get_workspaces_table(self.poetry.file.read())
+
+        fmt = self.option("format") or "all"
+
+        if parent:
+            parent_path = Path(parent).resolve()
+            parent_poetry = Factory().create_poetry(parent_path, io=self.io)
+            self._build_workspace(parent_poetry, self.poetry, fmt)
+
+        elif workspaces:
+            for ws, path in workspaces.items():
+                workspace_poetry = Factory().create_poetry(Path(path).resolve(), io=self.io)
+                self.line(f"Changing workspace to <c1>{ws}</c1>", verbosity=Verbosity.VERBOSE)
+                self._build_workspace(self.poetry, workspace_poetry, fmt)
+
+        else:
+            self.line(f"Not in workspace, falling back to regular build.")
+            self.call("build")
+
+        return 0
+
+    def _build(self, poetry, fmt):
+        package = poetry.package
+        self.line(
+            f"Building <c1>{package.pretty_name}</c1> (<c2>{package.version}</c2>)"
+        )
+        io = self.io
+
+        env_manager = EnvManager(poetry)
+        env = env_manager.create_venv(io)
+
+        if env.is_venv() and io.is_verbose():
+            io.write_line(f"Using virtualenv: <comment>{env.path}</>")
+
+        builder = Builder(poetry)
+        builder.build(fmt, executable=env.python)
+
+    def _workspace_dependency_constraint(self, workspace, version, file) -> str:
+        dependency_range = ""
+        default_dependency_range = get_dependency_range(file)
+        if default_dependency_range is not None:
+            dependency_range = default_dependency_range
+        workspace_dependency_range = get_dependency_ranges(file).get(workspace)
+        if workspace_dependency_range is not None:
+            dependency_range = workspace_dependency_range
+
+        if dependency_range == "*":
+            return dependency_range
+        elif dependency_range == "~" or dependency_range == "^" or dependency_range == "":
+            return f"{dependency_range}{version}"
+        else:
+            raise AssertionError(f"Dependency range constraint '{dependency_range}' not supported")
+
+    def _build_workspace(self, root, workspace, fmt):
+        workspaces = get_workspaces_table(root.file.read())
+        package = workspace.package
+
+        ws_deps = {}
+        for dependency in package.requires:
+            dep_name = dependency.name
+            if dep_name in workspaces and \
+                    dep_name not in ws_deps:
+                ws_dep_path = root.file.parent.joinpath(workspaces[dep_name])
+                project = Factory().create_poetry(ws_dep_path, io=self.io)
+                ws_deps[dep_name] = (dependency, project)
+
+        # rewrite directory dependencies to versioned dependencies
+        for name, (dependency, project) in ws_deps.items():
+            if isinstance(dependency, DirectoryDependency):
+                constraint = self._workspace_dependency_constraint(name, project.package.version, workspace.file.read())
+                regular_dep = Dependency(
+                    name=dependency.name,
+                    constraint=constraint,
+                    groups=dependency.groups,
+                    optional=dependency._optional,
+                    allows_prereleases=True,
+                    extras=dependency.extras
+                )
+                for group in dependency.groups:
+                    package.dependency_group(group).remove_dependency(dependency.name)
+                    package.dependency_group(group).add_dependency(regular_dep)
+
+        self._build(workspace, fmt)

--- a/poetry_workspace_plugin/helpers.py
+++ b/poetry_workspace_plugin/helpers.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from tomlkit.api import table
 from tomlkit.items import Table
 from tomlkit.toml_document import TOMLDocument
@@ -18,3 +20,24 @@ def get_workspace_section(pyproject: TOMLDocument) -> Table:
     if PLUGIN_SECTION not in tool_section:  # type: ignore
         tool_section[PLUGIN_SECTION] = table()  # type: ignore
     return tool_section[PLUGIN_SECTION]  # type: ignore
+
+
+def get_parent(pyproject: TOMLDocument) -> Optional[str]:
+    workspace_section = get_workspace_section(pyproject)
+    if "parent" not in workspace_section:
+        return None
+    return workspace_section["parent"]  # type: ignore
+
+
+def get_dependency_range(pyproject: TOMLDocument) -> Optional[str]:
+    workspace_section = get_workspace_section(pyproject)
+    if "dependency-range" not in workspace_section:
+        return None
+    return workspace_section["dependency-range"]  # type: ignore
+
+
+def get_dependency_ranges(pyproject: TOMLDocument) -> Table:
+    workspace_section = get_workspace_section(pyproject)
+    if "dependency-ranges" not in workspace_section:
+        workspace_section["dependency-ranges"] = table()  # type: ignore
+    return workspace_section["dependency-ranges"]  # type: ignore

--- a/poetry_workspace_plugin/plugin.py
+++ b/poetry_workspace_plugin/plugin.py
@@ -1,6 +1,7 @@
 from poetry.plugins.application_plugin import ApplicationPlugin
 
 from poetry_workspace_plugin.console.commands.add import WorkspaceAddCommand
+from poetry_workspace_plugin.console.commands.build import WorkspaceBuildCommand
 from poetry_workspace_plugin.console.commands.dependees import WorkspaceDependeesCommand
 from poetry_workspace_plugin.console.commands.list import WorkspaceListCommand
 from poetry_workspace_plugin.console.commands.new import WorkspaceNewCommand
@@ -16,3 +17,4 @@ class WorkspacePlugin(ApplicationPlugin):
         application.command_loader.register_factory("workspace run", WorkspaceRunCommand)
         application.command_loader.register_factory("workspace remove", WorkspaceRemoveCommand)
         application.command_loader.register_factory("workspace dependees", WorkspaceDependeesCommand)
+        application.command_loader.register_factory("workspace build", WorkspaceBuildCommand)


### PR DESCRIPTION
Any related Github Issues?: _add link here_ 

_What has changed? This should match `CHANGELOG.md`._

This PR introduces a `workspace build` command, which builds workspaces and replaces the directory reference of each workspace dependency with its version in the distribution manifest during packaging similarly to the way Cargo, Yarn and npm workspaces do.

### Design choices:

#### Doesn't change the default poetry behavior
According to the poetry documentation, an application plugin shouldn't change the behavior of the default poetry commands.  https://python-poetry.org/docs/master/plugins/. Thus, instead of augmenting `poetry build`, I introduced a new plugin command `poetry workspace build`.

#### Executable from the root or from within a workspace

The `workspace build` command can be executed in the root package, in which case traverses each workspace and runs the build (with the augmented logic) in their respective environments. It can also be executed from within the confines of an individual workspace. This way way it will only build the workspace for which it is invoked. To be able to discover the root which is necessary for wiring the deps, I introduced a `parent` field in `tool.poetry-workspace-plugin-table`.
Alternative approaches:
- if we don't want to invoke `workspace build` from within a workspace, the parent project discovery is not required
- we could do a recursive directory traversal up to the fs root to find the parent project instead

#### Configurable ranges

By default, `workspace build` uses the exact version for each workspace dependency. However, following the design of Yarn, we could allow for ranges. https://yarnpkg.com/features/workspaces
I propose following notation:
- `<empty string>`: exact version
- `^` / `~`: caret / tilde range on the exact version
- `*`: any version (wildcard)
- `.*`: minor wilcard (e.g `4.1.2` -> `4.*`) (TBD)
- `..*`: patch wildcard (e.g `4.1.2` -> `4.1.*`) (TBD)

The code quality has to be improved and there are no test yet, but can be tried it in this example project:
https://github.com/dszakallas/poetry-workspace-plugin-build-example

# Check list

## Before asking for a review

- [ ] Target branch is `master`
- [ ] Implement tests
- [ ] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [ ] I reviewed the "Files changed" tab and self-annotated anything unexpected.


## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.
